### PR TITLE
feat: add remaining routes and tests

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -6,7 +6,12 @@ use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::routes::workspace::{workspace_routes, workspaces::workspaces_routes};
+use crate::routes::{
+    event::event_routes,
+    form::form_routes,
+    section::section_routes,
+    workspace::{workspace_routes, workspaces::workspaces_routes},
+};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -43,6 +48,9 @@ pub fn create_router(db: DatabaseConnection) -> Result<Router> {
     let (router, api): (Router, utoipa::openapi::OpenApi) = OpenApiRouter::<AppState>::new()
         .merge(workspace_routes())
         .merge(workspaces_routes())
+        .merge(event_routes())
+        .merge(section_routes())
+        .merge(form_routes())
         .with_state(app_state.clone())
         .split_for_parts();
 

--- a/backend/src/dto.rs
+++ b/backend/src/dto.rs
@@ -1,1 +1,4 @@
+pub mod event;
+pub mod form;
+pub mod section;
 pub mod workspace;

--- a/backend/src/dto/event.rs
+++ b/backend/src/dto/event.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct EventRequest {
+    pub title: String,
+    pub workspace_id: Uuid,
+    pub description: Option<String>,
+    pub starts_at: Option<DateTime<FixedOffset>>,
+    pub ends_at: Option<DateTime<FixedOffset>>,
+    pub settings: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct UpdateEventRequest {
+    pub id: Uuid,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub starts_at: Option<DateTime<FixedOffset>>,
+    pub ends_at: Option<DateTime<FixedOffset>>,
+    pub settings: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct EventResponse {
+    pub id: Uuid,
+    pub title: String,
+    pub workspace_id: Uuid,
+    pub description: Option<String>,
+    pub starts_at: Option<DateTime<FixedOffset>>,
+    pub ends_at: Option<DateTime<FixedOffset>>,
+    pub settings: Option<Value>,
+}
+
+impl From<crate::model::event::Model> for EventResponse {
+    fn from(value: crate::model::event::Model) -> Self {
+        Self {
+            id: value.id,
+            title: value.title,
+            workspace_id: value.workspace_id,
+            description: value.description,
+            starts_at: value.starts_at,
+            ends_at: value.ends_at,
+            settings: value.settings,
+        }
+    }
+}

--- a/backend/src/dto/form.rs
+++ b/backend/src/dto/form.rs
@@ -1,0 +1,28 @@
+use crate::model::form;
+use chrono::{NaiveDate, NaiveDateTime};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct FormRequest {
+    pub event_id: Uuid,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub schema: Option<serde_json::Value>,
+    pub settings: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UpdateFormRequest {
+    pub id: Uuid,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub schema: Option<serde_json::Value>,
+    pub settings: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct FormResponse {
+    pub form: form::Model,
+}

--- a/backend/src/dto/section.rs
+++ b/backend/src/dto/section.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::model::section;
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct SectionRequest {
+    pub event_id: Uuid,
+    pub title: String,
+    pub price: f64,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct UpdateSectionRequest {
+    pub id: Uuid,
+    pub title: Option<String>,
+    pub price: Option<f64>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, ToSchema, Debug)]
+pub struct SectionResponse {
+    // pub id: Uuid,
+    // pub event_id: Uuid,
+    // pub title: String,
+    // pub price: f64,
+    // pub created_at: NaiveDateTime,
+    // pub updated_at: NaiveDateTime,
+    pub section: section::Model,
+}

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -17,6 +17,9 @@ pub enum AppError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
     #[error("Validation error: {0}")]
     Validation(String),
 
@@ -45,6 +48,7 @@ impl IntoResponse for AppError {
             }
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, "Not found", Some(msg)),
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized", None),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "Bad request", Some(msg)),
             AppError::Validation(msg) => (StatusCode::BAD_REQUEST, "Validation error", Some(msg)),
             AppError::Internal => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/model/form.rs
+++ b/backend/src/model/form.rs
@@ -2,8 +2,9 @@
 
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, ToSchema)]
 #[sea_orm(table_name = "form")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/backend/src/model/section.rs
+++ b/backend/src/model/section.rs
@@ -2,8 +2,9 @@
 
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize, ToSchema)]
 #[sea_orm(table_name = "section")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,1 +1,4 @@
+pub mod event;
+pub mod form;
+pub mod section;
 pub mod workspace;

--- a/backend/src/routes/event.rs
+++ b/backend/src/routes/event.rs
@@ -1,0 +1,125 @@
+use crate::app::AppState;
+use crate::dto::event::{EventRequest, EventResponse, UpdateEventRequest};
+use crate::dto::workspace::DeleteResponse;
+use crate::error::AppError;
+use crate::model::event;
+use axum::extract::{Path, Query};
+use axum::{Json, extract::State};
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel};
+use std::collections::HashMap;
+use std::iter::Iterator;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+pub fn event_routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(get_event, create_event, delete_event, update_event))
+}
+
+#[utoipa::path(
+    get,
+    path = "/event/{id}",
+    tag = "event",
+    responses((status = 200, body = EventResponse))
+)]
+pub async fn get_event(
+    State(app_state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<EventResponse>, AppError> {
+    let event = event::Entity::find_by_id(id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Event not found".to_string()))?;
+    Ok(Json(EventResponse::from(event)))
+}
+
+#[utoipa::path(
+    post,
+    path = "/event",
+    tag = "event",
+    request_body = EventRequest,
+    responses((status = 200, body = EventResponse))
+)]
+async fn create_event(
+    State(app_state): State<AppState>,
+    Json(body): Json<EventRequest>,
+) -> Result<Json<EventResponse>, AppError> {
+    let event = event::ActiveModel {
+        title: Set(body.title),
+        workspace_id: Set(body.workspace_id),
+        description: Set(body.description),
+        starts_at: Set(body.starts_at),
+        ends_at: Set(body.ends_at),
+        settings: Set(body.settings),
+        ..Default::default()
+    };
+    let event = event.insert(&*app_state.db).await?;
+    Ok(Json(EventResponse::from(event)))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/event",
+    tag = "event",
+    params(
+        ("event_id" = Uuid, Query, description = "ID of the event to delete")
+    ),
+    responses((status = 200, body = DeleteResponse))
+)]
+async fn delete_event(
+    State(app_state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<DeleteResponse>, AppError> {
+    let event_id: Uuid = params
+        .get("event_id")
+        .ok_or(AppError::BadRequest(
+            "Missing `event_id` query parameter".to_string(),
+        ))?
+        .parse()
+        .map_err(|_| AppError::BadRequest("Invalid UUID for `event_id`".to_string()))?;
+
+    let result = event::Entity::delete_by_id(event_id)
+        .exec(&*app_state.db)
+        .await?;
+
+    Ok(Json(DeleteResponse {
+        rows_affected: result.rows_affected,
+    }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/event",
+    tag = "event",
+    request_body = UpdateEventRequest,
+    responses((status = 200, body = EventResponse))
+)]
+async fn update_event(
+    State(app_state): State<AppState>,
+    Json(body): Json<UpdateEventRequest>,
+) -> Result<Json<EventResponse>, AppError> {
+    let mut event = event::Entity::find_by_id(body.id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Event not found".to_string()))?
+        .into_active_model();
+
+    if let Some(title) = body.title {
+        event.title = Set(title);
+    }
+    if let Some(description) = body.description {
+        event.description = Set(Some(description));
+    }
+    if let Some(starts_at) = body.starts_at {
+        event.starts_at = Set(Some(starts_at));
+    }
+    if let Some(ends_at) = body.ends_at {
+        event.ends_at = Set(Some(ends_at));
+    }
+    if let Some(settings) = body.settings {
+        event.settings = Set(Some(settings));
+    }
+
+    let updated_event = event.update(&*app_state.db).await?;
+    Ok(Json(EventResponse::from(updated_event)))
+}

--- a/backend/src/routes/form.rs
+++ b/backend/src/routes/form.rs
@@ -1,0 +1,127 @@
+use crate::app::AppState;
+use crate::dto::form::{FormRequest, FormResponse, UpdateFormRequest};
+use crate::dto::workspace::DeleteResponse;
+use crate::error::AppError;
+use crate::model::form;
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait, IntoActiveModel};
+use std::collections::HashMap;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+pub fn form_routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(create_form, get_form, update_form, delete_form))
+}
+
+#[utoipa::path(
+    post,
+    path = "/form",
+    tag = "form",
+    request_body = FormRequest,
+    responses((status = 200, body = FormResponse))
+)]
+async fn create_form(
+    State(app_state): State<AppState>,
+    Json(body): Json<FormRequest>,
+) -> Result<Json<FormResponse>, AppError> {
+    let form = form::ActiveModel {
+        event_id: Set(body.event_id),
+        title: Set(body.title),
+        description: Set(body.description),
+        schema: Set(body.schema.map(Into::into)),
+        settings: Set(body.settings.map(Into::into)),
+        ..Default::default()
+    };
+
+    let form = form.insert(&*app_state.db).await?;
+    Ok(Json(FormResponse { form }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/form/{form_id}",
+    tag = "form",
+    responses((status = 200, body = FormResponse))
+)]
+async fn get_form(
+    State(app_state): State<AppState>,
+    Path(form_id): Path<Uuid>,
+) -> Result<Json<FormResponse>, AppError> {
+    let form = form::Entity::find_by_id(form_id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Form not found".to_string()))?;
+
+    Ok(Json(FormResponse { form }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/form",
+    tag = "form",
+    request_body = UpdateFormRequest,
+    responses((status = 200, body = FormResponse))
+)]
+async fn update_form(
+    State(app_state): State<AppState>,
+    Json(body): Json<UpdateFormRequest>,
+) -> Result<Json<FormResponse>, AppError> {
+    let mut form = form::Entity::find_by_id(body.id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Form not found".to_string()))?
+        .into_active_model();
+
+    if let Some(title) = body.title {
+        form.title = Set(Some(title));
+    }
+    if let Some(description) = body.description {
+        form.description = Set(Some(description));
+    }
+    if let Some(schema) = body.schema {
+        form.schema = Set(Some(schema.into()));
+    }
+    if let Some(settings) = body.settings {
+        form.settings = Set(Some(settings.into()));
+    }
+
+    let updated_form = form.update(&*app_state.db).await?;
+    Ok(Json(FormResponse { form: updated_form }))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/form",
+    tag = "form",
+    params(
+        ("form_id" = Uuid, Query, description = "ID of the form to delete")
+    ),
+    responses((status = 200, body = DeleteResponse))
+)]
+async fn delete_form(
+    State(app_state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<DeleteResponse>, AppError> {
+    let form_id: Uuid = params
+        .get("form_id")
+        .ok_or(AppError::BadRequest(
+            "Missing `form_id` query parameter".to_string(),
+        ))?
+        .parse()
+        .map_err(|_| AppError::BadRequest("Invalid UUID for `form_id`".to_string()))?;
+
+    let result = form::Entity::delete_by_id(form_id)
+        .exec(&*app_state.db)
+        .await?;
+
+    if result.rows_affected == 0 {
+        return Err(AppError::NotFound("Form not found".to_string()));
+    }
+
+    Ok(Json(DeleteResponse {
+        rows_affected: result.rows_affected,
+    }))
+}

--- a/backend/src/routes/section.rs
+++ b/backend/src/routes/section.rs
@@ -1,0 +1,126 @@
+use std::collections::HashMap;
+
+use crate::app::AppState;
+use crate::dto::section::{SectionRequest, SectionResponse, UpdateSectionRequest};
+use crate::dto::workspace::DeleteResponse;
+use crate::error::AppError;
+use crate::model::section;
+use axum::extract::Query;
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, EntityTrait, IntoActiveModel};
+use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
+
+pub fn section_routes() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new().routes(routes!(
+        get_section,
+        create_section,
+        delete_section,
+        update_section
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/section/{id}",
+    tag = "section",
+    responses((status = 200, body = SectionResponse))
+)]
+pub async fn get_section(
+    State(app_state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<SectionResponse>, AppError> {
+    let section = section::Entity::find_by_id(id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Section not found".to_string()))?;
+    Ok(Json(SectionResponse { section }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/section",
+    tag = "section",
+    request_body = SectionRequest,
+    responses((status = 200, body = SectionResponse))
+)]
+async fn create_section(
+    State(app_state): State<AppState>,
+    Json(body): Json<SectionRequest>,
+) -> Result<Json<SectionResponse>, AppError> {
+    let section = section::ActiveModel {
+        event_id: Set(body.event_id),
+        title: Set(body.title),
+        price: Set(body.price),
+        ..Default::default()
+    };
+
+    let section = section.insert(&*app_state.db).await?;
+    Ok(Json(SectionResponse { section }))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/section",
+    tag = "section",
+    params(
+    ("section_id" = Uuid, Query),
+    ),
+    responses((status = 200, body = DeleteResponse))
+)]
+async fn delete_section(
+    State(app_state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<DeleteResponse>, AppError> {
+    let section_id: Uuid = params
+        .get("id")
+        .ok_or(AppError::BadRequest(
+            "Missing `id` query parameter".to_string(),
+        ))?
+        .parse()
+        .map_err(|_| AppError::BadRequest("Invalid UUID for `id`".to_string()))?;
+    let result = section::Entity::delete_by_id(section_id)
+        .exec(&*app_state.db)
+        .await?;
+
+    if result.rows_affected == 0 {
+        return Err(AppError::NotFound("Section not found".to_string()));
+    }
+
+    Ok(Json(DeleteResponse {
+        rows_affected: result.rows_affected,
+    }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/section",
+    tag = "section",
+    request_body = UpdateSectionRequest,
+    responses((status = 200, body = SectionResponse))
+)]
+async fn update_section(
+    State(app_state): State<AppState>,
+    Json(body): Json<UpdateSectionRequest>,
+) -> Result<Json<SectionResponse>, AppError> {
+    let mut section = section::Entity::find_by_id(body.id)
+        .one(&*app_state.db)
+        .await?
+        .ok_or(AppError::NotFound("Section not found".to_string()))?
+        .into_active_model();
+
+    if let Some(title) = body.title {
+        section.title = Set(title);
+    }
+    if let Some(price) = body.price {
+        section.price = Set(price);
+    }
+
+    let updated_section = section.update(&*app_state.db).await?;
+    Ok(Json(SectionResponse {
+        section: updated_section,
+    }))
+}

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -1,26 +1,73 @@
-use axum::Router;
-use backend::{app::create_router, model::workspace};
-use chrono::{DateTime, NaiveDateTime};
-use eyre::Result;
-use sea_orm::MockDatabase;
-use uuid::Uuid;
+#[allow(dead_code)]
+pub mod helpers {
 
-pub async fn create_test_app(mock_db: MockDatabase) -> Result<Router> {
-    let db = mock_db.into_connection();
-    Ok(create_router(db)?)
-}
+    use axum::Router;
+    use backend::{
+        app::create_router,
+        model::{event, form, section, workspace},
+    };
+    use chrono::{DateTime, NaiveDateTime};
+    use eyre::Result;
+    use sea_orm::MockDatabase;
+    use uuid::Uuid;
 
-pub fn mock_datetime() -> NaiveDateTime {
-    DateTime::from_timestamp(1700000000, 0).unwrap().naive_utc()
-}
+    pub async fn create_test_app(mock_db: MockDatabase) -> Result<Router> {
+        let db = mock_db.into_connection();
+        Ok(create_router(db)?)
+    }
 
-pub fn mock_workspace(id: Uuid, name: &str, owner_id: &str) -> workspace::Model {
-    let now = mock_datetime();
-    workspace::Model {
-        id,
-        name: name.to_string(),
-        owner_id: owner_id.to_string(),
-        created_at: now,
-        updated_at: now,
+    pub fn mock_datetime() -> NaiveDateTime {
+        DateTime::from_timestamp(1700000000, 0).unwrap().naive_utc()
+    }
+
+    pub fn mock_workspace(id: Uuid, name: &str, owner_id: &str) -> workspace::Model {
+        let now = mock_datetime();
+        workspace::Model {
+            id,
+            name: name.to_string(),
+            owner_id: owner_id.to_string(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+    pub fn mock_section(id: Uuid, title: &str, event_id: Uuid, price: f64) -> section::Model {
+        let now = mock_datetime();
+        section::Model {
+            id,
+            event_id,
+            title: title.to_string(),
+            price,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn mock_event(id: Uuid, title: &str, workspace_id: Uuid) -> event::Model {
+        let now = mock_datetime();
+        event::Model {
+            id,
+            workspace_id,
+            title: title.to_string(),
+            description: None,
+            starts_at: None,
+            ends_at: None,
+            settings: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn mock_form(id: Uuid, event_id: Uuid, title: &str, description: &str) -> form::Model {
+        let now = mock_datetime();
+        form::Model {
+            id,
+            event_id,
+            title: Some(title.to_string()),
+            description: Some(description.to_string()),
+            schema: None,
+            settings: None,
+            created_at: now,
+            updated_at: now,
+        }
     }
 }

--- a/backend/tests/test_event.rs
+++ b/backend/tests/test_event.rs
@@ -1,0 +1,124 @@
+use axum_test::TestServer;
+use backend::dto::event::{EventRequest, EventResponse, UpdateEventRequest};
+use backend::dto::workspace::DeleteResponse;
+use eyre::Result;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::json;
+use uuid::Uuid;
+
+mod common;
+use crate::common::helpers::{create_test_app, mock_event};
+
+#[tokio::test]
+async fn get_event() -> Result<()> {
+    let id = Uuid::new_v4();
+    let workspace_id = Uuid::new_v4();
+    let title = "Test Event";
+
+    let mock_data = mock_event(id, title, workspace_id);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_data.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server.get(format!("/event/{}", id).as_str()).await;
+
+    response.assert_status_ok();
+    let json: EventResponse = response.json();
+    assert_eq!(json.id, id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_event() -> Result<()> {
+    let id = Uuid::new_v4();
+    let workspace_id = Uuid::new_v4();
+    let title = "Test Event";
+
+    let expected = mock_event(id, title, workspace_id);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![expected.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server
+        .post("/event")
+        .json(&json!(EventRequest {
+            title: title.to_string(),
+            workspace_id,
+            description: None,
+            starts_at: None,
+            ends_at: None,
+            settings: None,
+        }))
+        .await;
+
+    response.assert_status_ok();
+    let json: EventResponse = response.json();
+    assert_eq!(json.id, id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_event() -> Result<()> {
+    let id = Uuid::new_v4();
+
+    let mock_db =
+        MockDatabase::new(DatabaseBackend::Postgres).append_exec_results(vec![MockExecResult {
+            rows_affected: 1,
+            last_insert_id: 0,
+        }]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server
+        .delete(format!("/event?event_id={}", id).as_str())
+        .await;
+
+    response.assert_status_ok();
+    let expected = DeleteResponse { rows_affected: 1 };
+    response.assert_json(&expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_event() -> Result<()> {
+    let id = Uuid::new_v4();
+    let workspace_id = Uuid::new_v4();
+    let old_title = "Old Event";
+    let new_title = "Updated Event";
+
+    let mock_old = mock_event(id, old_title, workspace_id);
+    let mock_new = mock_event(id, new_title, workspace_id);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_old.clone()]])
+        .append_query_results(vec![vec![mock_new.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server
+        .put("/event")
+        .json(&json!(UpdateEventRequest {
+            id,
+            title: Some(new_title.to_string()),
+            description: None,
+            starts_at: None,
+            ends_at: None,
+            settings: None,
+        }))
+        .await;
+
+    response.assert_status_ok();
+    let json: EventResponse = response.json();
+    assert_eq!(json.id, id);
+    assert_eq!(json.title, new_title);
+    Ok(())
+}

--- a/backend/tests/test_form.rs
+++ b/backend/tests/test_form.rs
@@ -1,0 +1,100 @@
+use axum_test::TestServer;
+use backend::dto::form::{FormRequest, FormResponse, UpdateFormRequest};
+use backend::dto::workspace::DeleteResponse;
+use eyre::Result;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::json;
+use uuid::Uuid;
+mod common;
+use crate::common::helpers::{create_test_app, mock_form};
+
+#[tokio::test]
+async fn get_form() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let title = "Test Form";
+    let description = "Test Description";
+    let mock_data = mock_form(id, event_id, title, description);
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_data.clone()]]);
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+    let response = server.get(format!("/form/{}", id).as_str()).await;
+    response.assert_status_ok();
+    response.assert_json(&FormResponse { form: mock_data });
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_form() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let title = "Test Form";
+    let description = "Test Description";
+    let expected = mock_form(id, event_id, title, description);
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![expected.clone()]]);
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+    let response = server
+        .post("/form")
+        .json(&json!(FormRequest {
+            event_id,
+            title: Some(title.to_string()),
+            description: Some(description.to_string()),
+            schema: None,
+            settings: None,
+        }))
+        .await;
+    response.assert_status_ok();
+    response.assert_json(&FormResponse { form: expected });
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_form() -> Result<()> {
+    let id = Uuid::new_v4();
+    let mock_db =
+        MockDatabase::new(DatabaseBackend::Postgres).append_exec_results(vec![MockExecResult {
+            rows_affected: 1,
+            last_insert_id: 0,
+        }]);
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+    let response = server
+        .delete(format!("/form?form_id={}", id).as_str())
+        .await;
+    response.assert_status_ok();
+    let expected = DeleteResponse { rows_affected: 1 };
+    response.assert_json(&expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_form() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let old_title = "Old Form";
+    let new_title = "Updated Form";
+    let description = "Test Description";
+    let mock_old = mock_form(id, event_id, old_title, description);
+    let mock_new = mock_form(id, event_id, new_title, description);
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_old.clone()]])
+        .append_query_results(vec![vec![mock_new.clone()]]);
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+    let response = server
+        .put("/form")
+        .json(&json!(UpdateFormRequest {
+            id,
+            title: Some(new_title.to_string()),
+            description: Some(description.to_string()),
+            schema: None,
+            settings: None,
+        }))
+        .await;
+    response.assert_status_ok();
+    response.assert_json(&FormResponse { form: mock_new });
+    Ok(())
+}

--- a/backend/tests/test_section.rs
+++ b/backend/tests/test_section.rs
@@ -1,0 +1,114 @@
+use axum_test::TestServer;
+use backend::dto::section::{SectionRequest, SectionResponse, UpdateSectionRequest};
+use backend::dto::workspace::DeleteResponse;
+use eyre::Result;
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use serde_json::json;
+use uuid::Uuid;
+
+mod common;
+use crate::common::helpers::{create_test_app, mock_section};
+
+#[tokio::test]
+async fn get_section() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let title = "Test Section";
+    let price = 100.0;
+
+    let mock_data = mock_section(id, title, event_id, price);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_data.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server.get(format!("/section/{}", id).as_str()).await;
+
+    response.assert_status_ok();
+    response.assert_json(&SectionResponse { section: mock_data });
+
+    Ok(())
+}
+#[tokio::test]
+async fn create_section() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let title = "Test Section";
+    let price = 100.0;
+
+    let expected = mock_section(id, title, event_id, price);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![expected.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server
+        .post("/section")
+        .json(&json!(SectionRequest {
+            event_id,
+            title: title.to_string(),
+            price,
+        }))
+        .await;
+
+    response.assert_status_ok();
+    response.assert_json(&SectionResponse { section: expected });
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_section() -> Result<()> {
+    let id = Uuid::new_v4();
+
+    let mock_db =
+        MockDatabase::new(DatabaseBackend::Postgres).append_exec_results(vec![MockExecResult {
+            rows_affected: 1,
+            last_insert_id: 0,
+        }]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server.delete(format!("/section?id={}", id).as_str()).await;
+
+    response.assert_status_ok();
+    let expected = DeleteResponse { rows_affected: 1 };
+    response.assert_json(&expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn update_section() -> Result<()> {
+    let id = Uuid::new_v4();
+    let event_id = Uuid::new_v4();
+    let old_title = "Old Section";
+    let new_title = "Updated Section";
+    let price = 50.0;
+
+    let mock_old = mock_section(id, old_title, event_id, price);
+    let mock_new = mock_section(id, new_title, event_id, price);
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![mock_old.clone()]])
+        .append_query_results(vec![vec![mock_new.clone()]]);
+
+    let app = create_test_app(mock_db).await?;
+    let server = TestServer::new(app).unwrap();
+
+    let response = server
+        .put("/section")
+        .json(&json!(UpdateSectionRequest {
+            id,
+            title: Some(new_title.to_string()),
+            price: Some(price),
+        }))
+        .await;
+
+    response.assert_status_ok();
+    response.assert_json(&SectionResponse { section: mock_new });
+    Ok(())
+}


### PR DESCRIPTION
This PR does
- add routes and tests for form, section, and event
- change delete method to use query
- add new dto for form, section, and event

Closes #8